### PR TITLE
Add .gitignore file and explicitly fork test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Forge build output directories
+cache/
+out/
+
+# Environment files just in case
+.env
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*.sublime-workspace
+.vscode/
+.idea/

--- a/test/LiquidLottery.t.sol
+++ b/test/LiquidLottery.t.sol
@@ -28,6 +28,7 @@ contract LiquidLotteryTest is Test {
     address constant WITNET_ORACLE_ADDRESS = 0xC0FFEE98AD1434aCbDB894BbB752e138c1006fAB;
 
     function setUp() public {
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"));
         _lottery = new LiquidLottery(
             AAVE_POOL_PROVIDER,
             WITNET_ORACLE_ADDRESS,


### PR DESCRIPTION
1.) Added .gitignore to avoid unnecessarily  pushing forges build output and any .env files in case they are added in the future

2.) It seems the LiquidLottery test is forking mainnet, so I made that explicit in the setup() function just to make it clearer. 